### PR TITLE
Add Timezone to User

### DIFF
--- a/user.go
+++ b/user.go
@@ -11,6 +11,7 @@ type User struct {
 	ApiToken string `json:"api_token"`
 	Email    string `json:"email"`
 	FullName string `json:"fullname"`
+	Timezone string `json:"timezone"`
 }
 type UserUpdate struct {
 	Email    string `json:"email"`


### PR DESCRIPTION
Timezone is a string representing the [IANA time zone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). This property is mentioned in the [Toggl API user docs](https://github.com/toggl/toggl_api_docs/blob/master/chapters/users.md#users).
